### PR TITLE
feat: add broken-backlinks audit type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs
 .DS_Store
 test-results.xml
 .env
+.idea

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import {
 import secrets from '@adobe/helix-shared-secrets';
 import { isObject, resolveSecretsName } from '@adobe/spacecat-shared-utils';
 
-const SUPPORTED_TYPES = ['cwv', '404', 'lhs', 'test'];
+const SUPPORTED_TYPES = ['cwv', '404', 'lhs', 'test', 'broken-backlinks'];
 
 /* c8 ignore next 3 */
 export const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1


### PR DESCRIPTION
This PR adds the `broken-backlinks` as supported audit type for [SITES-18417](https://jira.corp.adobe.com/browse/SITES-18417).
Relates to https://github.com/adobe/spacecat-audit-worker/pull/77, https://github.com/adobe/spacecat-audit-post-processor/pull/37

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
